### PR TITLE
refresh access tokens before expiry

### DIFF
--- a/src/token.rs
+++ b/src/token.rs
@@ -1,5 +1,7 @@
 use crate::{error::Error, token_cache::CacheableToken};
-use std::time::SystemTime;
+use std::time::{Duration, SystemTime};
+
+const ACCESS_TOKEN_REFRESH_WINDOW: Duration = Duration::from_secs(10 * 60);
 
 /// Represents a access token as returned by `OAuth2` servers.
 ///
@@ -37,7 +39,11 @@ impl CacheableToken for Token {
 
         let expiry = self.expires_in_timestamp.unwrap_or_else(SystemTime::now);
 
-        expiry <= SystemTime::now()
+        let refresh_deadline = SystemTime::now()
+            .checked_add(ACCESS_TOKEN_REFRESH_WINDOW)
+            .unwrap_or_else(SystemTime::now);
+
+        expiry <= refresh_deadline
     }
 }
 

--- a/src/token_cache.rs
+++ b/src/token_cache.rs
@@ -285,7 +285,7 @@ mod test {
     fn test_cache() {
         let cache = TokenCache::new();
         let hash = hash_scopes(&["scope1", "scope2"].iter());
-        let token = mock_token(100);
+        let token = mock_token(3600);
         let expired_token = mock_token(-100);
 
         assert!(matches!(
@@ -309,11 +309,25 @@ mod test {
     }
 
     #[test]
+    fn test_cache_refreshes_token_before_expiry() {
+        let cache = TokenCache::new();
+        let hash = hash_scopes(&["scope1", "scope2"].iter());
+        let almost_expired_token = mock_token(60);
+
+        cache.insert(almost_expired_token, hash).unwrap();
+
+        assert!(matches!(
+            cache.get(hash).unwrap(),
+            TokenOrRequestReason::RequestReason(RequestReason::Expired)
+        ));
+    }
+
+    #[test]
     fn test_cache_wrapper() {
         let cached_provider = CachedTokenProvider::wrap(PanicProvider);
 
         let hash = hash_scopes(&["scope1", "scope2"].iter());
-        let token = mock_token(100);
+        let token = mock_token(3600);
 
         cached_provider.access_tokens.insert(token, hash).unwrap();
 


### PR DESCRIPTION
## Summary

Refresh cached access tokens before they reach their exact expiry time.

tame-oauth previously reused cached access tokens until expiry <= now. TiKV's GCS client can start long requests with tokens that are technically still valid locally but close enough to expiry to fail during the request. This change treats access tokens expiring within 10 minutes as expired, causing the existing TokenOrRequest::Request flow to fetch a fresh token before the service request is sent.

## Changes

- Add a 10 minute access-token refresh window in Token::has_expired.
- Add a regression test proving near-expiry cached tokens trigger RequestReason::Expired.
- Adjust existing cache tests so reusable token fixtures are outside the refresh window.

## Validation

- cargo test test_cache_refreshes_token_before_expiry
- cargo test token_cache::test::test_cache
- cargo test
- rustfmt --check src/token.rs src/token_cache.rs

Note: full cargo fmt --check currently reports pre-existing formatting differences in src/jwt.rs, outside this PR's changed files.